### PR TITLE
Fix test import path

### DIFF
--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,11 @@
+"""Simple tests for the Game class."""
+
+from pathlib import Path
+import sys
+
+# Ensure the src package is discoverable when running tests directly with ``pytest``.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from src.core.game import Game
 
 


### PR DESCRIPTION
## Summary
- ensure the `src` package is discoverable when running tests with `pytest`

## Testing
- `pytest -q`
- ❌ `flake8 src/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edc3045d0832aa184e36e79dd6e38